### PR TITLE
Update openmodularturrets.cfg

### DIFF
--- a/common/config/openmodularturrets.cfg
+++ b/common/config/openmodularturrets.cfg
@@ -64,14 +64,14 @@ modcompatibility {
 
 
 turretbasetierfive {
-    I:BlastResistance=10
+    I:BlastResistance=90
     I:MaxCharge=10000000
     I:MaxIo=5000
 }
 
 
 turretbasetierfour {
-    I:BlastResistance=10
+    I:BlastResistance=60
     I:MaxCharge=500000
     I:MaxIo=1500
 }
@@ -85,7 +85,7 @@ turretbasetierone {
 
 
 turretbasetierthree {
-    I:BlastResistance=10
+    I:BlastResistance=30
     I:MaxCharge=150000
     I:MaxIo=500
 }


### PR DESCRIPTION
increases higher tier turret blast protection to that of advanced hullblocks... 
its a high teir turret armored to all hell... why would a creeper destroy it but not my hullblocks?